### PR TITLE
Update for OSX compile issues

### DIFF
--- a/src/zooadd.c
+++ b/src/zooadd.c
@@ -10,6 +10,7 @@
 #ifdef HAVE_NFTW
 #define _XOPEN_SOURCE 500	/* Rrequired on GLIBC */
 #define _GNU_SOURCE		/* -- " -- " -- " --  */
+#define _POSIX_C_SOURCE 200809L	/* -- " -- " -- " --  */
 #include <ftw.h>
 #endif
 


### PR DESCRIPTION
Defining _POSIX_C_SOURCE to a value equal or greater than 200809L allows us to re-acquire non-standard library functions (strdup() in our case is a posix extension) that strict ANSI checking allows.